### PR TITLE
Minor build updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@
 // application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
 // for the correction version of Gradle to use for the Ghidra installation you specify.
 
+plugins {
+	id 'java'
+}
+
 //----------------------START "DO NOT MODIFY" SECTION------------------------------
 def ghidraInstallDir = "/home/h1k0/sectools/ghidra_11.0.3_PUBLIC" // Modify `ghidraInstallDir` to your Ghidra installation directory
 
@@ -46,6 +50,12 @@ else {
 	throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(25)
+	}
+}
 
 sourceSets {
 	main {
@@ -70,8 +80,8 @@ dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
 	// this extension is built.
 
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.13.0'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.0'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.0'
 	implementation 'org.jgrapht:jgrapht-core:1.5.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Changes made as part of building for Ghidra 12 with JDK 25. Likely the current build scripts would work fine for Ghidra 12 with JDK 21.

- Added the "java" plugin and set the language version. Ghidra 12 requires a minimum of JDK 21, so version 25 is slightly overkill. That said, it hasn't broken anything in my (limited) experience. Setting the language version also helps my IDE to adjust code hints.
- Bumped Gradle to 9.1.0 to match JDK 25.
- Updated Jackson's minor version due to some reported vulnerabilities.